### PR TITLE
Fix offline caching and fully automate deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ swagger-ui.sublime-workspace
 .idea
 .project
 node_modules/*
+deploy.local.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - npm install
+after_success:
+  - bash deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-language: node_js
-node_js:
-  - '0.10'
-install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - npm install
-after_success:
+language: generic
+script:
   - bash deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,108 @@
+#!/bin/env bash
+
+if [[ -f `pwd`/deploy.local.sh ]]; then
+    . `pwd`/deploy.local.sh
+fi
+
+if [[ ! $APP_NAME ]]; then
+    read -p "Enter app name: " APP_NAME
+fi
+if [[ ! $CF_API ]]; then
+    read -p "Enter cloudfoundry API endpoint: " CF_API
+fi
+if [[ ! $CF_DOMAIN ]]; then
+    read -p "Enter cloudfoundry DOMAIN: " CF_DOMAIN
+fi
+if [[ ! $CF_ORG ]]; then
+    read -p "Enter cloudfoundry ORG: " CF_ORG
+fi
+if [[ ! $CF_SPACE ]]; then
+    read -p "Enter cloudfoundry SPACE: " CF_SPACE
+fi
+if [[ ! $CF_USER ]]; then
+    read -p "Enter cloudfoundry username: " CF_USER
+fi
+if [[ ! $CF_PASS ]]; then
+    read -s -p "Enter cloudfoundry password: " CF_PASS
+fi
+
+ECHO_CMD=`which echo`
+
+# suffix from $1 for app name
+SUFFIX=${1:-""}
+APP_NAME="${APP_NAME}${SUFFIX}"
+APP_ROUTE="${APP_NAME}-unstable"
+
+# check autodeploy
+if [[ $CF_AUTODEPLOY == true ]]; then
+    echo "Autodeploying"
+    if [[ $TRAVIS_PULL_REQUEST == true ]]; then
+        echo "Aborting, pull-request detected"
+        exit 0;
+    fi
+    APP_ROUTE="${APP_NAME}-${TRAVIS_BRANCH}"
+    if [[ $TRAVIS_BRANCH == 'master' ]]; then
+        APP_ROUTE=$APP_NAME
+        echo "Deploying prod to ${APP_NAME}"
+    elif [[ $TRAVIS_BRANCH == 'develop' ]]; then
+        echo "Deploying test to ${APP_NAME}-${TRAVIS_BRANCH}"
+    else
+        echo 'Not deploying due to wrong branch'
+        exit 0;
+    fi
+
+    APP_NAME="${APP_NAME}-${TRAVIS_BRANCH}"
+fi
+
+echo "Deploying at route ${APP_ROUTE}"
+
+CF_CMD=`which cf`
+
+if [[ $CF_CMD == '' ]]; then
+    curl -o /tmp/cf-linux-amd64.tgz http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.10.0/cf-linux-amd64.tgz
+    tar xvf /tmp/cf-linux-amd64.tgz -C /tmp
+    echo "Using downloaded cf cli"
+    CF_CMD="/tmp/cf"
+fi
+
+$CF_CMD api $CF_API
+# call behind pipe to ensure that $CF_CMD login is not interactive
+echo '' | $CF_CMD login -u $CF_USER -p $( $ECHO_CMD -n $CF_PASS) -o $CF_ORG -s $CF_SPACE
+if [[ $? -ne 0 ]]; then
+    echo "Auth failed"
+    echo "Exited with non-zero exit code"
+    exit 1;
+fi
+
+# push webinterface (does a green/blue deploy w/o rollback support)
+$CF_CMD app "${APP_NAME}-blue"
+if [[ $? -eq 0 ]]; then
+    DEPLOY_TARGET="${APP_NAME}-green"
+    OLD_TARGET="${APP_NAME}-blue"
+fi
+$CF_CMD app "${APP_NAME}-green"
+if [[ $? -eq 0 ]]; then
+    DEPLOY_TARGET="${APP_NAME}-blue"
+    OLD_TARGET="${APP_NAME}-green"
+fi
+
+if [[ ! $DEPLOY_TARGET ]]; then
+    echo "Initial Deploy, remember to set up the DB"
+    DEPLOY_TARGET="${APP_NAME}-blue"
+    OLD_TARGET="${APP_NAME}-green"
+fi
+
+echo "Deploying API to ${DEPLOY_TARGET}"
+$CF_CMD push $DEPLOY_TARGET
+if [[ $? -ne 0 ]]; then
+    echo "Push to ${DEPLOY_TARGET}failed"
+    echo "Exited with non-zero exit code"
+    exit 1;
+fi
+echo "Deploy to ${DEPLOY_TARGET} was successful, remapping routes"
+$CF_CMD map-route $DEPLOY_TARGET $CF_DOMAIN -n $APP_ROUTE
+$CF_CMD unmap-route $OLD_TARGET $CF_DOMAIN -n $APP_ROUTE
+echo "Reaping ${OLD_TARGET}"
+$CF_CMD stop $OLD_TARGET
+$CF_CMD delete $OLD_TARGET -f
+echo "So Long, and Thanks for All the Fish"

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html manifest="app.manifest">
+<html manifest="/app.manifest">
 <head>
   <title>Swagger UI</title>
   <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: swagger
-  buildpack: https://github.com/cloudfoundry-incubator/staticfile-buildpack.git
+  buildpack: https://github.com/hairmare/staticfile-buildpack.git#feature/html5-cache-manifest-mimetype
   paths:
   - dist/
-  memory: 128M
+  memory: 64M

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: swagger
-  buildpack: https://github.com/hairmare/staticfile-buildpack.git#feature/html5-cache-manifest-mimetype
+  buildpack: https://github.com/cloudfoundry-incubator/staticfile-buildpack.git
   paths:
   - dist/
   memory: 64M

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html manifest="app.manifest">
+<html manifest="/app.manifest">
 <head>
   <title>Swagger UI</title>
   <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>


### PR DESCRIPTION
On merging this to ``develop`` it will bring up ``swagger-develop-blue`` in the cloud at the route ``swagger-develop.nova``. Upon subsequent merges to ``develop`` it should then replace that instance with ``swagger-develop-green`` and switch routes without any downtime.

Upon merging this to ``master`` (using ``git flow release``? I dunno, how would we keep in sync with upstreams versioning) it will do the same thing with ``swagger-master-(blue|green)`` on the ``swagger.nova`` route.

Please note that this pr points at master but should go through develop. This is an exception I'm talking in this single case ;)

* [ ] rewrite to jenkins
* [ ] use graviton/deploy-scripts